### PR TITLE
Don't error if there's no masonry on the page

### DIFF
--- a/public/javascript/app.js
+++ b/public/javascript/app.js
@@ -1,11 +1,14 @@
 var grid = document.querySelector('.grid');
-var msnry = new Masonry( grid, {
-  itemSelector: '.grid-item',
-  columnWidth: 50,
-  fitWidth: true,
-  gutter: 3,
-  stagger: 30,
-});
+
+if (grid) {
+  var msnry = new Masonry( grid, {
+    itemSelector: '.grid-item',
+    columnWidth: 50,
+    fitWidth: true,
+    gutter: 3,
+    stagger: 30,
+  });
+}
 
 hljs.initHighlightingOnLoad();
 


### PR DESCRIPTION
Right now we assume there's a grid element. I don't know why we would do that. Let's only try to load up masonry if there is a grid element available. 